### PR TITLE
Update triangle_spec.rb

### DIFF
--- a/spec/triangle_spec.rb
+++ b/spec/triangle_spec.rb
@@ -41,23 +41,22 @@ describe 'Triangle' do
   end
 
   it 'knows that triangles with no size are illegal' do
-    expect{Triangle.new(0, 0, 0).kind}.to raise_error(TriangleError)
+    expect{Triangle.new(0, 0, 0).kind}.to raise_error(Triangle::TriangleError || TriangleError)
   end
 
   it 'knows that triangles with negative sides are illegal' do
-    expect{Triangle.new(3, 4, -5).kind}.to raise_error(TriangleError)
+    expect{Triangle.new(3, 4, -5).kind}.to raise_error(Triangle::TriangleError || TriangleError)
   end
 
   it 'knows that triangles violating triangle inequality are illegal' do
-    expect{Triangle.new(1, 1, 3).kind}.to raise_error(TriangleError)
+    expect{Triangle.new(1, 1, 3).kind}.to raise_error(Triangle::TriangleError || TriangleError)
   end
 
   it 'knows that triangles violating triangle inequality are illegal 2' do
-    expect{Triangle.new(2, 4, 2).kind}.to raise_error(TriangleError)
+    expect{Triangle.new(2, 4, 2).kind}.to raise_error(Triangle::TriangleError || TriangleError)
   end
 
   it 'knows that triangles violating triangle inequality are illegal 3' do
-    expect{Triangle.new(7, 3, 2).kind}.to raise_error(TriangleError)
+    expect{Triangle.new(7, 3, 2).kind}.to raise_error(Triangle::TriangleError || TriangleError)
   end
-
 end


### PR DESCRIPTION
These edits fall more in line with the previous lesson where custom errors are explained. In all the examples in that lesson they nest the error class within the Person class. In this lesson it is expected that it falls outside the Triangle class. This code better aligns with previous lessons and makes the tests a little more forgiving.